### PR TITLE
Update components me-menu-nav, user-page correctly from window hash

### DIFF
--- a/src/components/home/user-page/user-page.tsx
+++ b/src/components/home/user-page/user-page.tsx
@@ -54,6 +54,10 @@ export class UserPage {
         );
     }
 
+    componentDidLoad() {
+        this.handleHashChange();
+    }
+
     handleHashChange() {
         this.selectedItem = this.getNavItemFromWindowHash();
     }

--- a/src/components/menu-nav/menu-nav.tsx
+++ b/src/components/menu-nav/menu-nav.tsx
@@ -4,7 +4,7 @@
 
 import { Component, h, State } from "@stencil/core";
 import { Item } from "../nav/nav-item";
-import { getNavItems } from "./user-nav-data";
+import { getNavItemByHash, getNavItems } from "./user-nav-data";
 
 const ITEMS = getNavItems();
 
@@ -25,6 +25,30 @@ export class MenuNav {
                 onItemClick={ (e: CustomEvent<Item>) => this.onNavItemClick(e) }
             />
         );
+    }
+
+    componentWillLoad() {
+        window.addEventListener(
+            "hashchange",
+            () => this.handleHashChange.apply(this),
+        );
+    }
+
+    disconnectedCallback() {
+        window.removeEventListener(
+            "hashchange",
+            () => this.handleHashChange.apply(this),
+        );
+    }
+
+    componentDidLoad() {
+        this.handleHashChange();
+    }
+
+    handleHashChange() {
+        const hash = window.location.hash.replace("#", "");
+
+        this.selectedItem = getNavItemByHash(hash);
     }
 
     onNavItemClick({ detail }: CustomEvent<Item>) {


### PR DESCRIPTION
It fixes situations when the navigation menu and content page fails to update their state according to the window hash changes or page reloads.